### PR TITLE
Improve the look of the social links in the authorbox

### DIFF
--- a/themes/mainroad/assets/css/style.css
+++ b/themes/mainroad/assets/css/style.css
@@ -887,7 +887,11 @@ button:not(:-moz-focusring):focus > .menu__btn-title {
 
 .authorbox__socials {
 	margin-top: 10px;
-	max-width: 600px;
+	text-align: center;
+}
+
+.authorbox__socials > .widget-social__item {
+	display: inline-block;
 }
 
 /* List content */

--- a/themes/mainroad/assets/css/style.css
+++ b/themes/mainroad/assets/css/style.css
@@ -865,7 +865,6 @@ button:not(:-moz-focusring):focus > .menu__btn-title {
 	line-height: 1.5;
 	border-top: 1px solid #ebebeb;
 	border-bottom: 1px solid #ebebeb;
-	max-width: 600px;
 }
 
 .authorbox__avatar {

--- a/themes/mainroad/layouts/partials/authorbox.html
+++ b/themes/mainroad/layouts/partials/authorbox.html
@@ -18,7 +18,6 @@
 	{{- end }}
 	{{- with $author.social }}
 	<div class="widget-social widget authorbox__socials">
-		<h4 class="widget-social__title widget__title">Social links</h4>
 		<div class="widget-social__content widget__content authorbox__socials">
 			{{- range $key, $val := . }}
 			<div class="widget-social__item widget__item authorbox__{{ $key }}">


### PR DESCRIPTION
This PR improves the look of the social links in the authorbox: the "Social Links" header is removed, and the social link buttons are adjusted to be side-to-side on one line, fit their size to their contents, and be centered within the authorbox. In line with this, the maximum width on the authorbox was removed, to occupy the full space of the screen instead.

Some possible additional changes are to add a minimum width to the social link buttons, and to return the maximum width of the authorbox but expanded to take up more of the space.

## Before
![image](https://user-images.githubusercontent.com/21304337/174495834-704c68d8-92df-43cc-ac58-a1d9e0c63421.png)

## After
![image](https://user-images.githubusercontent.com/21304337/174495853-830dd29e-4b18-42ba-8fd9-37bf5a799289.png)
